### PR TITLE
issue10 - updating to exclude template java files from sonar

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=generator-camel-project
 sonar.projectName=Apache Camel Project Generator
 sonar.sources=app
-sonar.exclusions=test/**
+sonar.exclusions=test/**,app/templates/*.java
 sonar.tests=test
 
 sonar.links.homepage=https://github.com/camel-tooling/generator-camel-project


### PR DESCRIPTION
Attempting to use the sonar-project.properties file to exclude template java files from Sonar analysis and avoid "Error during SonarQube Scanner execution"

Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>