### PR TITLE
issue18 - adding spring boot template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ For a Java DSL-based project, the structure looks like this:
     │               └── Launcher.java                  Java class aiding in launching from command line
 ```
 
+For a Spring-Boot based project, the structure looks like this:
+```
+├── README.md                                          Project Readme file
+├── pom.xml                                            Maven Project Object Model file
+└── src
+    ├── main
+    │   └── java
+    │       └── [your package name]
+    │           └── routes
+    │               └── SampleCamelApplication.java    Spring-Boot application class file
+        └── resources
+            └── application.properties                 Spring-Boot application properties file
+            └── camel-context.xml                      Camel configuration file (Spring XML DSL)
+```
+
 ## Installing the Camel Project generator
 
 You must have yeoman installed first:
@@ -77,12 +92,12 @@ The generator is located in the npm repository (https://www.npmjs.com/package/ge
      \____|   \__,_| |_| |_| |_|  \___| |_|
  -----------------------------------------------
             Camel Project Generator
-                 Version: 0.1.3
+                 Version: 0.2.0
  -----------------------------------------------
 
 ? Your Camel project name (myproject)
 ? Your Camel version 2.22.2
-? Camel DSL type (blueprint, spring, or java) blueprint
+? Camel DSL type (blueprint, spring, spring-boot, or java) blueprint
 ? Package name:  com.myproject
 camel project name myproject
 camel version 2.22.2
@@ -101,12 +116,12 @@ Copying files
 
 * 'Camel project name' defaults to the name of the directory in which you start the generator.
 * 'Camel version' currently defaults to 2.22.2 but if you provide a different version, that version then becomes the default for the next time the generator is run.
-* 'Camel DSL type' defaults to 'spring' but if you change it to a valid DSL type such as 'blueprint', 'spring', or 'java', that becomes the default for the next time the generator is run. If you enter an invalid value, the generator will present an error ">> Camel DSL must be either 'spring', 'blueprint', or 'java'.". Note that with the --wsdl2rest flag set, your DSL options are limited to 'spring' and 'blueprint'.
+* 'Camel DSL type' defaults to 'spring' but if you change it to a valid DSL type such as 'blueprint', 'spring', 'spring-boot', or 'java', that becomes the default for the next time the generator is run. If you enter an invalid value, the generator will present an error ">> Camel DSL must be either 'spring', 'blueprint', or 'java'.". Note that with the --wsdl2rest flag set, your DSL options are limited to 'spring', 'spring-boot', and 'blueprint'.
 * 'Package name' defaults to 'com.' + the name of the directory (i.e. 'com.myproject'). This default does not change if you provide a different value. Note that you may need to change the package name to make it valid if your directory/project name contains special characters.
 
 ### wsdl2rest Options
 
-As of version 0.1.3, you now have the option to scaffold a new Spring or Blueprint project based on an available WSDL file for a JAX-WS service. 
+As of version 0.2.0, you now have the option to scaffold a new Spring, Spring-Boot, or Blueprint project based on an available WSDL file for a JAX-WS service. 
 
 To run the generator with the additional wsdl2rest functionality, now you simply type:
 ```
@@ -186,6 +201,12 @@ Generated templates for spring, blueprint, and Java DSLs can be run with:
 ```
 > mvn install
 > mvn camel:run
+```
+
+Generated templates for spring-boot can be run with:
+```
+> mvn install
+> mvn spring-boot:run
 ```
 
 ## Known Issues

--- a/app/index.js
+++ b/app/index.js
@@ -91,7 +91,7 @@ module.exports = class extends yeoman {
         let showWsdl2Rest = this.options.wsdl2rest;
         if (typeof showWsdl2Rest == 'undefined') showWsdl2Rest = false;
 
-        var showW2RPrompts = true;
+        var showW2RPrompts = showPrompts;
         if (!showPrompts && showWsdl2Rest) {
             showW2RPrompts = (utils.isNull(this.options.wsdl)) &&
                 (utils.isNull(this.options.outdirectory)) &&
@@ -125,8 +125,8 @@ module.exports = class extends yeoman {
         utils.addPrompt({
             type: 'input',
             name: 'camelDSL',
-            message: 'Camel DSL type (blueprint, spring, or java)',
-            choices: ['blueprint', 'spring', 'java'],
+            message: 'Camel DSL type (blueprint, spring, spring-boot, or java)',
+            choices: ['blueprint', 'spring', 'spring-boot', 'java'],
             default: defaultDSL,
             validate: (value) => {
                 return utils.validateCamelDSL(value, showWsdl2Rest);
@@ -263,6 +263,7 @@ module.exports = class extends yeoman {
 var skipListForWsdl2RestFiles = [
     'src/main/resources/META-INF/spring/camel-context.xml',
     'src/main/resources/OSGI-INF/blueprint/blueprint.xml',
+    'src/main/resources/camel-context.xml',
     'pom.xml'
 ];
 
@@ -316,10 +317,16 @@ function wsdl2restGenerate(wsdlUrl, outputDirectory, jaxrs, jaxws, dsl, isDebug)
 
     var restContextPath;
     var rawContextPath;
-    var isBlueprint = dsl.includes('blueprint') > 0;
+
+    const isBlueprint = dsl.match('blueprint');
+    const isSpringBoot = dsl.match('spring-boot');
+    const isSpring = dsl.match('spring');
+
     if (isBlueprint) {
         rawContextPath = "src/main/resources/OSGI-INF/blueprint/blueprint.xml";
-    } else {
+    } else if (isSpringBoot) {
+        rawContextPath = "src/main/resources/camel-context.xml";
+    } else if (isSpring) {
         rawContextPath = "src/main/resources/META-INF/spring/camel-context.xml";
     }
     restContextPath = path.join(process.cwd(), rawContextPath);

--- a/app/templates/java/README.md
+++ b/app/templates/java/README.md
@@ -1,4 +1,4 @@
-<%= userProps.appName %>
+<%= userProps.name %>
 =============
 
 Camel Project for Java 

--- a/app/templates/spring-boot/README.md
+++ b/app/templates/spring-boot/README.md
@@ -1,7 +1,7 @@
 <%= userProps.name %>
 =============
 
-Camel Project for Blueprint 
+Camel Project for Spring Boot
 =========================================
 To build this project use
 ```bash
@@ -10,7 +10,7 @@ To build this project use
 
 To run the project you can execute the following Maven goal
 ```bash
-    mvn camel:run
+    mvn spring-boot:run
 ```
 
 For more help see the Apache Camel documentation

--- a/app/templates/spring-boot/pom.xml
+++ b/app/templates/spring-boot/pom.xml
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId><%= userProps.package %></groupId>
+	<artifactId><%= userProps.name %></artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name><%= userProps.name %></name>
+
+	<licenses>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<distribution>repo</distribution>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+		</license>
+	</licenses>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<version.maven-bundle-plugin>3.2.0</version.maven-bundle-plugin>
+		<camel.version><%= userProps.camelVersion %></camel.version>
+		<spring-boot-version>2.1.1.RELEASE</spring-boot-version>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<!-- Spring Boot BOM -->
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<version>${spring-boot-version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<!-- Camel BOM -->
+			<dependency>
+				<groupId>org.apache.camel</groupId>
+				<artifactId>camel-spring-boot-dependencies</artifactId>
+				<version>${camel.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<!-- Spring Boot -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-tomcat</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-undertow</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-stream-starter</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-core</artifactId>
+			<version>${camel.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-spring</artifactId>
+			<version>${camel.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-stream</artifactId>
+			<version>${camel.version}</version>
+		</dependency>
+
+		<!-- Testing & Camel Plugin -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-test-spring</artifactId>
+			<version>${camel.version}</version>
+		</dependency>
+	</dependencies>
+
+	<repositories>
+		<repository>
+			<id>red-hat-ga-repository</id>
+			<name>Red Hat GA Repository</name>
+			<url>https://maven.repository.redhat.com/ga</url>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>red-hat-ea-repository</id>
+			<name>Red Hat EA Repository</name>
+			<url>https://maven.repository.redhat.com/earlyaccess/all</url>
+		</repository>
+		<!-- To remove when a long-term version will be available -->
+		<repository>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>jboss-ea-repository</id>
+			<name>Red Hat JBoss Early Access Repository</name>
+			<url>http://repository.jboss.org/nexus/content/groups/ea</url>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>red-hat-ga-repository</id>
+			<name>Red Hat GA Repository</name>
+			<url>https://maven.repository.redhat.com/ga</url>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+		<pluginRepository>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>red-hat-ea-repository</id>
+			<name>Red Hat EA Repository</name>
+			<url>https://maven.repository.redhat.com/earlyaccess/all</url>
+		</pluginRepository>
+		<!-- To remove when a long-term version will be available -->
+		<pluginRepository>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>jboss-ea-repository</id>
+			<name>Red Hat JBoss Early Access Repository</name>
+			<url>http://repository.jboss.org/nexus/content/groups/ea</url>
+		</pluginRepository>
+	</pluginRepositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>${spring-boot-version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Allows the routes to be run via 'mvn spring-boot:run' -->
+			<plugin>
+				<groupId>org.apache.camel</groupId>
+				<artifactId>camel-maven-plugin</artifactId>
+				<version>${camel.version}</version>
+				<configuration>
+					<applicationContextUri>META-INF/spring/camel-context.xml</applicationContextUri>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+		<id>jdk9+-build</id>
+		<activation>
+			<jdk>[9,)</jdk>
+		</activation>
+		<build>
+			<plugins>
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>--add-modules java.xml.bind --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+				</configuration>
+			</plugin>
+			</plugins>
+		</build>
+		</profile>
+	</profiles>
+
+	<description>Empty Camel Spring Example</description>
+</project>

--- a/app/templates/spring-boot/pom.xml.wsdl2rest
+++ b/app/templates/spring-boot/pom.xml.wsdl2rest
@@ -1,0 +1,252 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId><%= userProps.package %></groupId>
+	<artifactId><%= userProps.name %></artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name><%= userProps.name %></name>
+
+	<licenses>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<distribution>repo</distribution>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+		</license>
+	</licenses>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<version.maven-bundle-plugin>3.2.0</version.maven-bundle-plugin>
+		<camel.version><%= userProps.camelVersion %></camel.version>
+		<spring-boot-version>2.1.1.RELEASE</spring-boot-version>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<!-- Spring Boot BOM -->
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<version>${spring-boot-version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<!-- Camel BOM -->
+			<dependency>
+				<groupId>org.apache.camel</groupId>
+				<artifactId>camel-spring-boot-dependencies</artifactId>
+				<version>${camel.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<!-- Spring Boot -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-tomcat</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-undertow</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-stream-starter</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-spring</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-stream</artifactId>
+		</dependency>
+
+		<!-- Testing & Camel Plugin -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-test-spring</artifactId>
+		</dependency>
+
+		<!-- wsdl2rest dependencies -->
+		<dependency>
+			<groupId>org.jboss.spec.javax.ws.rs</groupId>
+			<artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+			<version>1.0.0.Final-redhat-1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-jackson</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-cxf</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.camel</groupId>
+			<artifactId>camel-jetty</artifactId>
+		</dependency>
+	</dependencies>
+
+	<repositories>
+		<repository>
+			<id>red-hat-ga-repository</id>
+			<name>Red Hat GA Repository</name>
+			<url>https://maven.repository.redhat.com/ga</url>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>red-hat-ea-repository</id>
+			<name>Red Hat EA Repository</name>
+			<url>https://maven.repository.redhat.com/earlyaccess/all</url>
+		</repository>
+		<!-- To remove when a long-term version will be available -->
+		<repository>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>jboss-ea-repository</id>
+			<name>Red Hat JBoss Early Access Repository</name>
+			<url>http://repository.jboss.org/nexus/content/groups/ea</url>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>red-hat-ga-repository</id>
+			<name>Red Hat GA Repository</name>
+			<url>https://maven.repository.redhat.com/ga</url>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+				<pluginRepository>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>red-hat-ea-repository</id>
+			<name>Red Hat EA Repository</name>
+			<url>https://maven.repository.redhat.com/earlyaccess/all</url>
+		</pluginRepository>
+		<!-- To remove when a long-term version will be available -->
+		<pluginRepository>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>jboss-ea-repository</id>
+			<name>Red Hat JBoss Early Access Repository</name>
+			<url>http://repository.jboss.org/nexus/content/groups/ea</url>
+		</pluginRepository>
+	</pluginRepositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>${spring-boot-version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Allows the routes to be run via 'mvn spring-boot:run' -->
+			<plugin>
+				<groupId>org.apache.camel</groupId>
+				<artifactId>camel-maven-plugin</artifactId>
+				<version>${camel.version}</version>
+				<configuration>
+					<applicationContextUri>META-INF/spring/camel-context.xml</applicationContextUri>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+		<id>jdk9+-build</id>
+		<activation>
+			<jdk>[9,)</jdk>
+		</activation>
+		<build>
+			<plugins>
+				<plugin>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<configuration>
+						<argLine>--add-modules java.xml.bind --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+					</configuration>
+				</plugin>
+			</plugins>
+		</build>
+		</profile>
+	</profiles>
+
+	<description>Empty Camel Spring Example</description>
+</project>

--- a/app/templates/spring-boot/src/main/java/routes/SampleCamelApplication.java
+++ b/app/templates/spring-boot/src/main/java/routes/SampleCamelApplication.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package <%= userProps.package %>.routes;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ImportResource;
+
+/**
+ * A sample Spring Boot application that starts the Camel routes.
+ */
+@SpringBootApplication
+
+// load the spring xml file from classpath
+@ImportResource("classpath:camel-context.xml")
+public class SampleCamelApplication {
+
+    /**
+     * A main method to start this application.
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(SampleCamelApplication.class, args);
+    }
+
+}

--- a/app/templates/spring-boot/src/main/resources/application.properties
+++ b/app/templates/spring-boot/src/main/resources/application.properties
@@ -1,0 +1,41 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+# the name of Camel
+camel.springboot.name = <%= userProps.name %>
+
+# to automatic shutdown the JVM after a period of time
+#camel.springboot.duration-max-seconds=60
+#camel.springboot.duration-max-messages=100
+
+# add for example: &repeatCount=5 to the timer endpoint to make Camel idle
+#camel.springboot.duration-max-idle-seconds=15
+
+# properties used in the Camel route and beans
+# --------------------------------------------
+
+# how often to trigger the timer
+timer.period = 2000
+
+# turn on actuator health check
+management.endpoint.health.enabled = true
+
+# to configure logging levels
+#logging.level.org.springframework = INFO
+#logging.level.org.apache.camel.spring.boot = INFO
+#logging.level.org.apache.camel.impl = DEBUG
+#logging.level.sample.camel = DEBUG

--- a/app/templates/spring-boot/src/main/resources/camel-context.xml
+++ b/app/templates/spring-boot/src/main/resources/camel-context.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2014-2017, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. 
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- Configures the Camel Context-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+    <camelContext id="_camelContext1" xmlns="http://camel.apache.org/schema/spring">
+        <route id="_route1">
+            <from uri="timer://simpleTimer?period=1000"/>
+            <setBody>
+                <simple>Hello from timer at ${header.firedTime}></simple>
+            </setBody>
+            <to uri="stream:out"/>
+        </route>
+    </camelContext>
+</beans>

--- a/app/templates/spring/README.md
+++ b/app/templates/spring/README.md
@@ -1,4 +1,4 @@
-<%= userProps.appName %>
+<%= userProps.name %>
 =============
 
 Camel Project for Spring 

--- a/app/util.js
+++ b/app/util.js
@@ -77,13 +77,14 @@ var reservedKeywords = {
 
 utils.validateCamelDSL = function (value, isWsdl2Rest) {
     const isBlueprint = value.match('blueprint');
+    const isSpringBoot = value.match('spring-boot');
     const isSpring = value.match('spring');
     const isJava = value.match('java');
     let returnValue;
-    if (!isWsdl2Rest && !isBlueprint && !isSpring && !isJava) {
-        returnValue = chalk.red('Camel DSL must be either \'spring\', \'blueprint\', or \'java\'.');
-    } else if (isWsdl2Rest && !isBlueprint && !isSpring) {
-        returnValue = chalk.red('When using wsdl2rest, the Camel DSL must be either \'spring\' or \'blueprint\'.');
+    if (!isWsdl2Rest && !isBlueprint && !isSpring && !isJava && !isSpringBoot) {
+        returnValue = chalk.red('Camel DSL must be either \'spring\', \'spring-boot\', \'blueprint\', or \'java\'.');
+    } else if (isWsdl2Rest && !isBlueprint && !isSpring && !isSpringBoot) {
+        returnValue = chalk.red('When using wsdl2rest, the Camel DSL must be either \'spring\', \'spring-boot\', or \'blueprint\'.');
     } else {
         returnValue = true;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-camel-project",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-camel-project",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Generates the scaffold for a Camel project with the given name.",
   "files": [
     "app",

--- a/test/generator_tests.js
+++ b/test/generator_tests.js
@@ -59,6 +59,42 @@ describe('generator-camel:app', function () {
     });
   });
 
+
+  describe('Should properly scaffold with default config for Spring Boot', function () {
+
+    before(function () {
+      basicProps.name = 'MyAppMock';
+      basicProps.package = 'com.generator.mock';
+      basicProps.camelVersion = defaultCamel;
+      basicProps.camelDSL = 'spring-boot';
+
+      return helpers.run(path.join(__dirname, '../app'))
+        .inTmpDir(function (dir) {
+          var done = this.async(); // `this` is the RunContext object.
+          fs.copy(path.join(__dirname, '../templates'), dir, done);
+        })
+        .withPrompts({ name: basicProps.name })
+        .withPrompts({ camelVersion: basicProps.camelVersion })
+        .withPrompts({ camelDSL: basicProps.camelDSL })
+        .withPrompts({ package: basicProps.package })
+        .toPromise();
+    });
+
+    it('Should create the basic structure', function () {
+      assert.file('pom.xml');
+      assert.file('README.md');
+      assert.file('src/main/resources/camel-context.xml');
+      assert.file('src/main/java/com/generator/mock/routes/SampleCamelApplication.java');
+      assert.noFile('pom.xml.wsdl2rest');
+    });
+
+    it('Should create pom.xml with default content', function () {
+      assert.fileContent('pom.xml', new RegExp('<groupId>' + basicProps.package + '</groupId>'));
+      assert.fileContent('pom.xml', new RegExp('<artifactId>' + basicProps.name + '</artifactId>'));
+      assert.fileContent('pom.xml', new RegExp('<spring-boot-version>'));
+    });
+  });
+
   describe('Should properly scaffold with default config for Blueprint', function () {
 
     before(function () {

--- a/test/utils_tests.js
+++ b/test/utils_tests.js
@@ -44,13 +44,15 @@ describe('generator-camel:app', function () {
     });
 
     it('validateCamelDSL should fail on java dsl with wsdl2rest active', function () {
-      // wsdl2rest only supports spring & blueprint, not java
+      // wsdl2rest only supports spring, spring-boot, & blueprint, not java
       assert.notStrictEqual(utils.validateCamelDSL('java', true), true);
+      assert.strictEqual(utils.validateCamelDSL('spring-boot', true), true);
       assert.strictEqual(utils.validateCamelDSL('spring', true), true);
       assert.strictEqual(utils.validateCamelDSL('blueprint', true), true);
 
-      // without wsdl2rest, java, spring & blueprint are supported
+      // without wsdl2rest, java, spring, spring-boot & blueprint are supported
       assert.strictEqual(utils.validateCamelDSL('java', false), true);
+      assert.strictEqual(utils.validateCamelDSL('spring-boot', false), true);
       assert.strictEqual(utils.validateCamelDSL('spring', false), true);
       assert.strictEqual(utils.validateCamelDSL('blueprint', false), true);
     });
@@ -59,11 +61,13 @@ describe('generator-camel:app', function () {
   it('validateCamelDSL should fail on java dsl with wsdl2rest active', function () {
     // wsdl2rest only supports spring & blueprint, not java
     assert.notStrictEqual(utils.validateCamelDSL('java', true), true);
+    assert.strictEqual(utils.validateCamelDSL('spring-boot', true), true);
     assert.strictEqual(utils.validateCamelDSL('spring', true), true);
     assert.strictEqual(utils.validateCamelDSL('blueprint', true), true);
 
     // without wsdl2rest, java, spring & blueprint are supported
     assert.strictEqual(utils.validateCamelDSL('java', false), true);
+    assert.strictEqual(utils.validateCamelDSL('spring-boot', false), true);
     assert.strictEqual(utils.validateCamelDSL('spring', false), true);
     assert.strictEqual(utils.validateCamelDSL('blueprint', false), true);
   });

--- a/test/wsdl2rest_tests.js
+++ b/test/wsdl2rest_tests.js
@@ -100,6 +100,39 @@ describe('generator-camel:wsdl2rest', function () {
         });
     });
 
+    it('Should create the basic structure and CXF files for spring-boot', function () {
+      basicProps.name = 'MyAppMock';
+      basicProps.package = 'com.generator.mock';
+      basicProps.camelVersion = defaultCamel;
+      basicProps.camelDSL = 'spring-boot';
+      var wsdlPath = path.join(__dirname, '../test/address.wsdl');
+      basicProps.wsdl = wsdlPath;
+      basicProps.outdirectory = 'src/main/java';
+      return helpers.run(path.join(__dirname, '../app'))
+        .inTmpDir(function (dir) {
+          var done = this.async(); // `this` is the RunContext object.
+          fs.copy(path.join(__dirname, '../templates'), dir, done);
+          basicProps.outdirectory = path.join(dir, 'src/main/java');
+        })
+        .withOptions({ wsdl2rest: true })
+        .withOptions({ debug: true })
+        .withPrompts({ name: basicProps.name })
+        .withPrompts({ camelVersion: basicProps.camelVersion })
+        .withPrompts({ camelDSL: basicProps.camelDSL })
+        .withPrompts({ package: basicProps.package })
+        .withPrompts({ wsdl: basicProps.wsdl })
+        .withPrompts({ outdirectory: basicProps.outdirectory })
+        .toPromise()
+        .then(() => {
+          assert.file('pom.xml');
+          assert.file('README.md');
+          assert.noFile('src/main/resources/META-INF/spring/camel-context.xml');
+          assert.file('src/main/resources/camel-context.xml');
+          assert.file('src/main/java/org/jboss/fuse/wsdl2rest/test/doclit/Address.java');
+          assert.noFile('pom.xml.wsdl2rest');
+        });
+    });
+
     it('Should create the basic structure and CXF files for spring with an internal running WSDL url', function () {
 
       basicProps.name = 'HelloWorld';


### PR DESCRIPTION
-- added spring-boot as supported DSL
-- added new spring-boot template
-- added new basic (not wsdl2rest) spring-boot test
-- added support for spring-boot with wsdl2rest
-- updated test for utils to include spring-boot
-- added new test for spring-boot with wsdl2rest
-- updated version to 0.2.0
-- updated README.md

Signed-off-by: Brian Fitzpatrick <bfitzpat@redhat.com>